### PR TITLE
Normalize apostrophes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,10 @@ deploy:
 install:
   - sudo apt-get install gcc libaspell-dev libaspell15 aspell
 jdk:
-  - openjdk6
+  - openjdk7
 language: scala
 scala:
-  - 2.10.5
-  - 2.11.6
+  - 2.10.6
+  - 2.11.7
 script:
   - sbt ++$TRAVIS_SCALA_VERSION package native:package

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ buildInfoKeys := Seq[BuildInfoKey](Jni.Keys.libraryName)
 
 buildInfoPackage := "com.lucidchart.aspell"
 
-crossScalaVersions := Seq("2.10.5", "2.11.6")
+crossScalaVersions := Seq("2.10.6", "2.11.7")
 
 credentials += Credentials(
   "Sonatype Nexus Repository Manager",
@@ -97,7 +97,7 @@ resourceGenerators in Native +=
     .dependsOn(Jni.Keys.jniCompile)
     .taskValue
 
-scalaVersion := "2.10.5"
+scalaVersion := "2.11.7"
 
 version := "2.1.0-SNAPSHOT"
 

--- a/src/main/scala/com/lucidchart/aspell/Aspell.scala
+++ b/src/main/scala/com/lucidchart/aspell/Aspell.scala
@@ -36,6 +36,15 @@ case class WordSuggestions(word: String, valid: Boolean, suggestions: Array[Stri
 object Aspell {
   NativeLibraryLoader.load(s"/${BuildInfo.libraryName}.so")
 
+  private val apostropheLike = "[\u2019\u02bc\u055a\uff07]".r
+  /**
+   * Normalize the word so that we can spell check words with
+   * special characters (such as non-ASCII apostrophes)
+   */
+  private def normalizeWord(word: String) = {
+    apostropheLike.replaceAllIn(word, "'")
+  }
+
   /**
    * Check the spelling for each word in an array of words
    *
@@ -54,7 +63,8 @@ object Aspell {
       aspell.addUserWords(userWords)
     }
     val checks = words.map { word =>
-      val wordCheck = aspell.check(word)
+      val normalized = normalizeWord(word)
+      val wordCheck = aspell.check(normalized)
       val valid = Try {
         if (wordCheck(0).toInt == 1) true else false
       }.getOrElse(false)

--- a/src/test/scala/com/lucidchart/aspell/AspellTest.scala
+++ b/src/test/scala/com/lucidchart/aspell/AspellTest.scala
@@ -1,14 +1,50 @@
 package com.lucidchart.aspell
 
 import org.specs2.mutable._
+import org.specs2.matcher.{Matcher, AlwaysMatcher}
 
 class AspellSpec extends Specification {
+  private def wordSuggestions(word: String, valid: Boolean, matchSuggestions: Matcher[Traversable[String]] = AlwaysMatcher()): Matcher[WordSuggestions] = {
+    beLike {
+      case WordSuggestions(`word`, `valid`, suggs) => suggs.toSeq must matchSuggestions
+    }
+  }
+
+  private def wordFound(word: String): Matcher[WordSuggestions] = {
+    beLike {
+      case WordSuggestions(`word`, true, _) => ok
+    }
+  }
 
   "Aspell" should {
 
     "work" in {
       Aspell.check("", Array(), Array())
       ok
+    }
+
+
+    "treat non-ASCII apostrophes as apostrophes" in {
+      Aspell.check("en", Array(
+        "I've",
+        "I\u2019ve",
+        "I\u02bcve",
+        "I\u055ave",
+        "I\uff07ve"), Array()).toSeq must contain(exactly(
+          wordFound("I've"),
+          wordFound("I\u2019ve"),
+          wordFound("I\u02bcve"),
+          wordFound("I\u055ave"),
+          wordFound("I\uff07ve")
+        ))
+
+      Aspell.check("en", Array("I\u2019v"), Array()).toSeq must contain(
+        wordSuggestions("I\u2019v", false, contain("I've"))
+      )
+
+      Aspell.check("en", Array("foo\u2019bar"), Array("foo'bar")).toSeq must contain(exactly(
+        wordFound("foo\u2019bar")
+      ))
     }
 
   }


### PR DESCRIPTION
Normalize apostrophes when doing a spell check.

Aspell doesn't handle non-ASCII apostrophe characters very well. This adds some code that normalizes such characters to ASCII apostrophes.
