### PR TITLE
upgrade sbt-jni version

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,10 @@
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.4.0")
 
-addSbtPlugin("com.github.joprice" % "sbt-jni" % "0.1.0")
+addSbtPlugin("com.github.joprice" % "sbt-jni" % "0.1.2")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.5.0")
 
-resolvers += Resolver.url("joprice maven", url("http://dl.bintray.com/content/joprice/maven"))(Resolver.ivyStylePatterns)
+resolvers += Resolver.url("joprice-sbt-plugins", url("http://dl.bintray.com/content/joprice/sbt-plugins"))(Resolver.ivyStylePatterns)
+

--- a/src/main/scala/com/lucidchart/aspell/Aspell.scala
+++ b/src/main/scala/com/lucidchart/aspell/Aspell.scala
@@ -34,7 +34,7 @@ case class WordSuggestions(word: String, valid: Boolean, suggestions: Array[Stri
  * library and has a method to check the spelling on a word.
  */
 object Aspell {
-  NativeLibraryLoader.load(s"/${BuildInfo.libraryName}.so")
+  NativeLibraryLoader.load(s"/${BuildInfo.libraryName}")
 
   /**
    * Check the spelling for each word in an array of words

--- a/src/main/scala/com/lucidchart/aspell/NativeLibraryLoader.scala
+++ b/src/main/scala/com/lucidchart/aspell/NativeLibraryLoader.scala
@@ -7,8 +7,8 @@ import resource._
 private[aspell] object NativeLibraryLoader {
 
   def load(name: String) = {
-    val tempDirectory = new File(System.getProperty("java.io.tmpdir"))
     val fileName = new File(getClass.getResource(name).getPath).getName
+    val tempDirectory = new File(System.getProperty("java.io.tmpdir"))
     val file = new File(tempDirectory + File.separator + fileName)
     for {
       libraryStream <- managed(getClass.getResourceAsStream(name))


### PR DESCRIPTION
I released a new version of sbt-jni, with the bug fix you contributed, along with some refactoring. The keys are not prefixed with 'jni' and the plugin defined as an AutoPlugin.

The library name suffix is now configurable, in order to deal with java's loadLibrary's pattern of adding an os-specific suffix. However, I noticed that you're using `getResource` to load the library. So, this PR won't yet maintain that same behavior (You will need to add the key `jniLibSuffix := ".so"`. 

However, I would also suggest adding 'darwin'/ 'osx' and 'linux' into the classifier. Here's an example of Netlib, which does something similar (although I think their classifier is 'natives', and version plays the OS configuration role): http://mvnrepository.com/artifact/com.github.fommil.netlib.

I did not attempt to debug the '--no-as-needed' flag. Perhaps you explain its purpose and a workaround?

I'd like to come up with a pattern for publishing for multiple architectures similar to the '+' operator of sbt, perhaps using docker, and add it to the sbt-jni readme.
